### PR TITLE
[Feat/#8] 사용자 정보 생성 API

### DIFF
--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package danpoong.mohaeng.user.controller;
+
+import danpoong.mohaeng.user.dto.UserCreateReq;
+import danpoong.mohaeng.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("")
+    public ResponseEntity<String> userCreate(@RequestBody UserCreateReq userCreateReq) {
+        if (!userService.createUser(userCreateReq.getUuid()))
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 존재하는 유저입니다.\n");
+
+        return ResponseEntity.status(HttpStatus.CREATED).body("유저 정보를 생성했습니다.\n");
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
@@ -1,27 +1,19 @@
 package danpoong.mohaeng.user.controller;
 
 import danpoong.mohaeng.user.dto.UserCreateReq;
-import danpoong.mohaeng.user.service.UserService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 
-@Controller
-@RequestMapping("/api/v1/user")
-@RequiredArgsConstructor
-public class UserController {
+public interface UserController{
 
-    private final UserService userService;
-
-    @PostMapping("")
-    public ResponseEntity<String> userCreate(@RequestBody UserCreateReq userCreateReq) {
-        if (!userService.createUser(userCreateReq.getUuid()))
-            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 존재하는 유저입니다.\n");
-
-        return ResponseEntity.status(HttpStatus.CREATED).body("유저 정보를 생성했습니다.\n");
-    }
+    @Operation(summary = "유저 생성 API", description = "uuid 기반으로 유저 정보를 생성하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "유저 정보를 생성했습니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 유저입니다.", content = @Content(mediaType = "application/json")),
+    })
+    public ResponseEntity<String> userCreate(@RequestBody UserCreateReq userCreateReq);
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
@@ -1,0 +1,29 @@
+package danpoong.mohaeng.user.controller;
+
+import danpoong.mohaeng.user.dto.UserCreateReq;
+import danpoong.mohaeng.user.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+@Tag(name = "User", description = "유저 관련 API")
+public class UserControllerImpl implements UserController {
+
+    private final UserService userService;
+
+    @PostMapping("")
+    public ResponseEntity<String> userCreate(@RequestBody UserCreateReq userCreateReq) {
+        if (!userService.createUser(userCreateReq.getUuid()))
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 존재하는 유저입니다.\n");
+
+        return ResponseEntity.status(HttpStatus.CREATED).body("유저 정보를 생성했습니다.\n");
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/dto/UserCreateReq.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/dto/UserCreateReq.java
@@ -1,0 +1,8 @@
+package danpoong.mohaeng.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserCreateReq {
+    private String uuid;
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/dto/UserCreateReq.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/dto/UserCreateReq.java
@@ -1,8 +1,10 @@
 package danpoong.mohaeng.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "uuid = 유저 고유 ID")
 public class UserCreateReq {
     private String uuid;
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/repository/UserRepository.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package danpoong.mohaeng.user.repository;
+
+import danpoong.mohaeng.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, String> {
+    boolean existsByUuid(String uuid);
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/service/UserService.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/service/UserService.java
@@ -1,0 +1,23 @@
+package danpoong.mohaeng.user.service;
+
+import danpoong.mohaeng.user.domain.User;
+import danpoong.mohaeng.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public boolean createUser(String uuid) {
+        if (userRepository.existsByUuid(uuid))
+            return false;
+
+        User createUser = new User(uuid);
+        userRepository.save(createUser);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## 구현 로직
유저 생성 API 구현에 따른 파일을 생성했습니다.

UserRepository의 existsByUuid를 통해 기존에 존재하는 유저 정보임을 먼저 확인합니다.

존재하는 유저인 경우 Conflict를 리턴합니다.
존재하지 않는 유저인 경우 유저 정보를 생성하고, Created를 리턴합니다.

## Swagger
어노테이션도 상속이 가능함을 이용해 유저 API 관련 Swagger 설정을 따로 관리하기 위한 인터페이스를 생성했습니다.

UserController라는 이름의 인터페이스를 생성하고, 기존의 UserController를 UserControllerImpl로 수정했습니다.

UserCreateReq에 @Schema를 추가해 Swagger에서 해당 DTO에 대한 설명을 추가했습니다.