### PR TITLE
[Feat/#9] 유저 존재 확인 API

### DIFF
--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
@@ -2,11 +2,13 @@ package danpoong.mohaeng.user.controller;
 
 import danpoong.mohaeng.user.dto.UserCreateReq;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface UserController{
 
@@ -16,4 +18,12 @@ public interface UserController{
             @ApiResponse(responseCode = "409", description = "이미 존재하는 유저입니다.", content = @Content(mediaType = "application/json")),
     })
     public ResponseEntity<String> userCreate(@RequestBody UserCreateReq userCreateReq);
+
+    @Operation(summary = "유저 존재 확인 API", description = "uuid 기반으로 유저 존재 여부를 확인하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 정보를 생성했습니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "이미 존재하는 유저입니다.", content = @Content(mediaType = "application/json")),
+    })
+    @Parameter(name = "uuid", description = "유저 고유 ID")
+    public ResponseEntity<String> userExist(@RequestParam("uuid") String uuid);
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
@@ -7,9 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/api/v1/user")
@@ -25,5 +23,13 @@ public class UserControllerImpl implements UserController {
             return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 존재하는 유저입니다.\n");
 
         return ResponseEntity.status(HttpStatus.CREATED).body("유저 정보를 생성했습니다.\n");
+    }
+
+    @GetMapping("/exist")
+    public ResponseEntity<String> userExist(@RequestParam("uuid") String uuid) {
+        if (userService.checkUserExist(uuid))
+            return ResponseEntity.status(HttpStatus.OK).body("유저가 존재합니다.\n");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("유저가 존재하지 않습니다\n");
     }
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/service/UserService.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/service/UserService.java
@@ -12,12 +12,16 @@ public class UserService {
     private final UserRepository userRepository;
 
     public boolean createUser(String uuid) {
-        if (userRepository.existsByUuid(uuid))
+        if (checkUserExist(uuid))
             return false;
 
         User createUser = new User(uuid);
         userRepository.save(createUser);
 
         return true;
+    }
+
+    public boolean checkUserExist(String uuid) {
+        return userRepository.existsByUuid(uuid);
     }
 }


### PR DESCRIPTION
## uuid 기반 유저 존재 여부 확인 API

UserService의 checkUserExist()를 통해 DB 내 동일 uuid가 존재하는지 확인합니다. 
유저가 존재하면 200, 존재하지 않으면 400을 리턴합니다.

또한, checkUserExist를 통해 기존 createUser 함수의 조건문 내용을 대체해 코드를 간결히 수정했습니다.

## Swagger 적용
유저 존재 확인 API에 Swagger를 적용했습니다.
간단한 API에 대한 설명과 응답 코드, 파라미터에 대한 설명을 덧붙였습니다.

close #9 