### PR TITLE
[Refactor/#16] 백업 SQL로 데이터 복원

### DIFF
--- a/Mohaeng/src/main/java/danpoong/mohaeng/area/domain/Area.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/area/domain/Area.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 @Getter @Setter
 public class Area {
     @Id
-    @Column(name = "number")
+    @Column(name = "area_code")
     private Long number;
 
     @Column(name = "name")

--- a/Mohaeng/src/main/java/danpoong/mohaeng/disabled/domain/Disabled.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/disabled/domain/Disabled.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 public class Disabled {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)  // disabled_number는 자동 생성
-    @Column(name = "number")
+    @Column(name = "disabled_number")
     private Long number;  // 장애시설코드
 
     @OneToOne


### PR DESCRIPTION
## 데이터 복원 세팅

도메인 컬럼과 DB 컬럼 이름이 달라 매핑 관련 문제가 발생해 백업 데이터 복원하기 전에 사전 작업을 진행했습니다.
프로젝트 내 변수명은 유지하되 DB와의 매핑 이름만 변경해주었습니다.

close #16 