### PR TITLE
[Feat/#17] 관광지 상세 정보 조회 API

### DIFF
--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationController.java
@@ -1,0 +1,20 @@
+package danpoong.mohaeng.location.controller;
+
+import danpoong.mohaeng.location.dto.LocationInfoRes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+public interface LocationController {
+    @Operation(summary = "관광지 상세 정보 조회 API", description = "contentId를 기반으로 관광지 상세 정보를 조회하는 API입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "관광지 상세 정보를 리턴합니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "관광지 정보를 조회할 수 없습니다.", content = @Content(mediaType = "application/json")),
+    })
+    @Parameter(name = "contentId", description = "관광지 고유 ID")
+    public ResponseEntity<LocationInfoRes> getInfo(@PathVariable("contentId") Long contentId);
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationControllerImpl.java
@@ -2,17 +2,19 @@ package danpoong.mohaeng.location.controller;
 
 import danpoong.mohaeng.location.dto.LocationInfoRes;
 import danpoong.mohaeng.location.service.LocationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/api/v1/location")
 @RequiredArgsConstructor
+@Tag(name = "Location", description = "관광지 관련 API")
 public class LocationControllerImpl implements LocationController {
 
     private final LocationService locationService;

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationControllerImpl.java
@@ -1,0 +1,29 @@
+package danpoong.mohaeng.location.controller;
+
+import danpoong.mohaeng.location.dto.LocationInfoRes;
+import danpoong.mohaeng.location.service.LocationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1/location")
+@RequiredArgsConstructor
+public class LocationControllerImpl implements LocationController {
+
+    private final LocationService locationService;
+
+    @GetMapping("/{contentId}")
+    public ResponseEntity<LocationInfoRes> getInfo(@PathVariable("contentId") Long contentId) {
+        LocationInfoRes locationInfoRes = locationService.getLocationInfo(contentId);
+
+        if (locationInfoRes == null)
+            ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+
+        return ResponseEntity.status(HttpStatus.OK).body(locationInfoRes);
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/dto/LocationInfoRes.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/dto/LocationInfoRes.java
@@ -1,0 +1,70 @@
+package danpoong.mohaeng.location.dto;
+
+import danpoong.mohaeng.disabled.domain.Disabled;
+import danpoong.mohaeng.location.domain.Location;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class LocationInfoRes {
+    //location 관련 컬럼
+    private Long contentId;
+    private String contentTitle;
+    private String addr;
+    private Double gpsX;
+    private Double gpsY;
+    private String description;
+    private String originalImage;
+    private String thumbnailImage;
+
+    //Disabled 관련 컬럼
+    //휠체어 사용자 && 노약자
+    private String publicTransport;
+    private String elevator;
+    private String restroom;
+    private String wheelchair;
+
+    //시각 장애인
+    private String helpDog;
+    private String guideHuman;
+    private String braileBlock;
+
+    //청각 장애인
+    private String signGuide;
+    private String videoGuide;
+    private String hearingHandicapEtc;
+
+    //영유아
+    private String stroller;
+    private String lactationRoom;
+    private String babySpareChair;
+
+    public static LocationInfoRes infoBuilder(Location location, Disabled disabled) {
+        return LocationInfoRes.builder()
+                .contentId(location.getContentId())
+                .contentTitle(location.getContentTitle())
+                .addr(location.getAddr())
+                .gpsX(location.getGpsX())
+                .gpsY(location.getGpsY())
+                .description(location.getDescription())
+                .originalImage(location.getOriginalImage())
+                .thumbnailImage(location.getThumbnailImage())
+                .publicTransport(disabled.getPublicTransport())
+                .elevator(disabled.getElevator())
+                .restroom(disabled.getRestroom())
+                .wheelchair(disabled.getWheelchair())
+                .helpDog(disabled.getHelpDog())
+                .guideHuman(disabled.getGuideHuman())
+                .braileBlock(disabled.getBraileBlock())
+                .signGuide(disabled.getSignGuide())
+                .videoGuide(disabled.getVideoGuide())
+                .hearingHandicapEtc(disabled.getHearingHandicapEtc())
+                .stroller(disabled.getStroller())
+                .lactationRoom(disabled.getLactationRoom())
+                .babySpareChair(disabled.getBabySpareChair())
+                .build();
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/service/LocationService.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/service/LocationService.java
@@ -1,0 +1,22 @@
+package danpoong.mohaeng.location.service;
+
+import danpoong.mohaeng.disabled.repository.DisabledRepository;
+import danpoong.mohaeng.location.domain.Location;
+import danpoong.mohaeng.location.dto.LocationInfoRes;
+import danpoong.mohaeng.location.repository.LocationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final LocationRepository locationRepository;
+    private final DisabledRepository disabledRepository;
+
+    public LocationInfoRes getLocationInfo(Long contentId) {
+        Location location = locationRepository.findLocationByContentId(contentId);
+
+        return LocationInfoRes.infoBuilder(location, disabledRepository.findDisabledByLocation(location));
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
@@ -6,10 +6,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
 @Tag(name = "User", description = "유저 관련 API")


### PR DESCRIPTION
## 관광지 상세 정보 조회 API
### getLocationInfo()
contentId를 기준으로 location을 조회하고, location을 기준으로 disabled를 조회합니다.
location, disabled를 바탕으로 LocationInfoRes를 생성해 리턴합니다.

LocationInfoRes는 관광지 기본 정보 및 장애 별 지원 시설 정보를 담고있습니다.
Response가 null이면 400을 리턴하고, 아니라면 200과 Response를 리턴합니다.

## Swagger 적용
Swagger를 통한 API 명세서 작성을 위한 코드를 구현했습니다.
LocationController 인터페이스를 통해 Swagger 어노테이션을 분리했습니다.

추가로 UserControllerImpl의 어노테이션을 수정해주었습니다.

close #17