### PR TITLE
[Feat/#22] 코스 등록 API

### DIFF
--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseController.java
@@ -1,0 +1,21 @@
+package danpoong.mohaeng.course.controller;
+
+import danpoong.mohaeng.course.dto.CourseCreateReq;
+import danpoong.mohaeng.course.dto.CourseCreateRes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Course", description = "코스 관련 API")
+public interface CourseController {
+    @Operation(summary = "코스 등록 API", description = "AI 추천 코스를 코스 등록하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "코스 정보를 생성했습니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "잘못된 코스 정보입니다.", content = @Content(mediaType = "application/json")),
+    })
+    public ResponseEntity<CourseCreateRes> courseCreate(@RequestBody CourseCreateReq courseCreateReq);
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseControllerImpl.java
@@ -1,0 +1,30 @@
+package danpoong.mohaeng.course.controller;
+
+import danpoong.mohaeng.course.dto.CourseCreateReq;
+import danpoong.mohaeng.course.dto.CourseCreateRes;
+import danpoong.mohaeng.course.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/course")
+@RequiredArgsConstructor
+public class CourseControllerImpl implements CourseController{
+
+    private final CourseService courseService;
+
+    @PostMapping("")
+    public ResponseEntity<CourseCreateRes> courseCreate(@RequestBody CourseCreateReq courseCreateReq) {
+        CourseCreateRes courseCreateRes = courseService.createTrip(courseCreateReq);
+
+        if (courseCreateRes == null || courseCreateRes.getDay1() == null)
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(courseCreateRes);
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/domain/Course.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/domain/Course.java
@@ -3,16 +3,11 @@ package danpoong.mohaeng.course.domain;
 import danpoong.mohaeng.area.domain.Area;
 import danpoong.mohaeng.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
+import lombok.*;
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "course")
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -25,11 +20,20 @@ public class Course {
     @Column(name = "name")
     private String name;
 
+    @Column(name = "period")
+    private Long period;
+
     @Column(name = "start_date")
     private LocalDate startDate;
 
     @Column(name = "end_date")
     private LocalDate endDate;
+
+    @Column(name = "gps_x")
+    private Double gpsX;
+
+    @Column(name = "gps_y")
+    private Double gpsY;
 
     @ManyToOne
     @JoinColumn(name = "uuid")
@@ -38,4 +42,16 @@ public class Course {
     @ManyToOne
     @JoinColumn(name = "area_number")
     private Area area;
+
+    @Builder
+    public Course(String name, Long period, LocalDate startDate, LocalDate endDate, Double gpsX, Double gpsY, User user, Area area) {
+        this.name = name;
+        this.period = period;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.gpsX = gpsX;
+        this.gpsY = gpsY;
+        this.user = user;
+        this.area = area;
+    }
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/domain/UserCourse.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/domain/UserCourse.java
@@ -18,6 +18,9 @@ public class UserCourse {
     @Column(name = "user_course_number")
     private Long userCourseNumber;
 
+    @Column(name = "day")
+    private Long day;
+
     @ManyToOne
     @JoinColumn(name = "course_number")
     private Course course;
@@ -27,7 +30,8 @@ public class UserCourse {
     private Location location;
 
     @Builder
-    public UserCourse(Course course, Location location) {
+    public UserCourse(Long day, Course course, Location location) {
+        this.day = day;
         this.course = course;
         this.location = location;
     }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/CourseCreateReq.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/CourseCreateReq.java
@@ -1,0 +1,48 @@
+package danpoong.mohaeng.course.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Schema(description = "코스 생성 요청 DTO")
+public class CourseCreateReq {
+
+    @Schema(description = "사용자 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
+    private String uuid;
+
+    @Schema(description = "코스 이름", example = "서울 여행 코스")
+    private String courseName;
+
+    @Schema(description = "지역 번호", example = "1")
+    private Long area;
+
+    @Schema(description = "GPS X 좌표", example = "37.5665")
+    private Double gpsX;
+
+    @Schema(description = "GPS Y 좌표", example = "126.9780")
+    private Double gpsY;
+
+    @Schema(description = "여행 기간 (일)", example = "3")
+    private Long period;
+
+    @Schema(description = "장애 유형 ID 리스트", example = "[1, 2]")
+    private List<Long> disability;
+
+    @Schema(description = "여행 타입 ID 리스트", example = "[3, 4]")
+    private List<Long> tripType;
+
+    @Schema(description = "여행 시작 날짜", example = "2024-12-01")
+    private LocalDate startDate;
+
+    @Schema(description = "첫째 날 방문 장소 ID 리스트", example = "[101, 102, 103]")
+    private List<Long> day1;
+
+    @Schema(description = "둘째 날 방문 장소 ID 리스트", example = "[201, 202, 203]")
+    private List<Long> day2;
+
+    @Schema(description = "셋째 날 방문 장소 ID 리스트", example = "[301, 302, 303]")
+    private List<Long> day3;
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/CourseCreateRes.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/CourseCreateRes.java
@@ -1,0 +1,63 @@
+package danpoong.mohaeng.course.dto;
+
+import danpoong.mohaeng.course.domain.Course;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Schema(description = "코스 생성 응답 DTO")
+public class CourseCreateRes {
+
+    @Schema(description = "사용자 UUID", example = "123e4567-e89b-12d3-a456-426614174000")
+    private String uuid;
+
+    @Schema(description = "코스 이름", example = "서울 여행 코스")
+    private String courseName;
+
+    @Schema(description = "GPS X 좌표", example = "37.5665")
+    private Double gpsX;
+
+    @Schema(description = "GPS Y 좌표", example = "126.9780")
+    private Double gpsY;
+
+    @Schema(description = "여행 기간 (일)", example = "3")
+    private Long period;
+
+    @Schema(description = "장애 유형 ID 리스트", example = "[1, 2]")
+    private List<Long> disability;
+
+    @Schema(description = "여행 시작 날짜", example = "2024-12-01")
+    private LocalDate startDate;
+
+    @Schema(description = "여행 종료 날짜", example = "2024-12-03")
+    private LocalDate endDate;
+
+    @Schema(description = "첫째 날 방문 장소 ID 리스트", example = "[101, 102, 103]")
+    private List<Long> day1;
+
+    @Schema(description = "둘째 날 방문 장소 ID 리스트", example = "[201, 202, 203]")
+    private List<Long> day2;
+
+    @Schema(description = "셋째 날 방문 장소 ID 리스트", example = "[301, 302, 303]")
+    private List<Long> day3;
+
+    @Builder
+    public CourseCreateRes(String uuid, Course course, List<Long> disability, LocalDate startDate, LocalDate endDate,
+                           List<Long> day1, List<Long> day2, List<Long> day3) {
+        this.uuid = uuid;
+        this.courseName = course.getName();
+        this.gpsX = course.getGpsX();
+        this.gpsY = course.getGpsY();
+        this.period = course.getPeriod();
+        this.disability = disability;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.day1 = day1;
+        this.day2 = day2;
+        this.day3 = day3;
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/repository/CourseRepository.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/repository/CourseRepository.java
@@ -1,0 +1,7 @@
+package danpoong.mohaeng.course.repository;
+
+import danpoong.mohaeng.course.domain.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/service/CourseService.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/service/CourseService.java
@@ -1,0 +1,117 @@
+package danpoong.mohaeng.course.service;
+
+import danpoong.mohaeng.area.domain.Area;
+import danpoong.mohaeng.area.repository.AreaRepository;
+import danpoong.mohaeng.course.domain.Course;
+import danpoong.mohaeng.course.domain.UserCourse;
+import danpoong.mohaeng.course.dto.CourseCreateReq;
+import danpoong.mohaeng.course.dto.CourseCreateRes;
+import danpoong.mohaeng.course.repository.CourseRepository;
+import danpoong.mohaeng.course.repository.UserCourseRepository;
+import danpoong.mohaeng.disability.domain.UserDisability;
+import danpoong.mohaeng.disability.repository.DisabilityRepository;
+import danpoong.mohaeng.disability.repository.UserDisabilityRepository;
+import danpoong.mohaeng.location.repository.LocationRepository;
+import danpoong.mohaeng.user.domain.User;
+import danpoong.mohaeng.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CourseService {
+    private final UserRepository userRepository;
+    private final UserCourseRepository userCourseRepository;
+    private final AreaRepository areaRepository;
+    private final LocationRepository locationRepository;
+    private final DisabilityRepository disabilityRepository;
+    private final UserDisabilityRepository userDisabilityRepository;
+    private final CourseRepository courseRepository;
+
+    public CourseCreateRes createTrip(CourseCreateReq courseCreateReq) {
+        // 코스 정보 생성
+        Course course = createCourse(courseCreateReq);
+
+        // 코스 장애 정보 생성
+        createCourseDisability(course, courseCreateReq.getDisability());
+
+        return crateCourseRes(course, courseCreateReq);
+    }
+
+    private Course createCourse(CourseCreateReq courseCreateReq) {
+        User user = userRepository.findUserByUuid(courseCreateReq.getUuid());
+        Area area = areaRepository.findByNumber(courseCreateReq.getArea());
+        LocalDate endDate = courseCreateReq.getStartDate().plusDays(courseCreateReq.getPeriod());
+
+        Course course = Course.builder()
+                .name(courseCreateReq.getCourseName())
+                .startDate(courseCreateReq.getStartDate())
+                .endDate(endDate)
+                .period(courseCreateReq.getPeriod())
+                .gpsX(courseCreateReq.getGpsX())
+                .gpsY(courseCreateReq.getGpsY())
+                .user(user)
+                .area(area)
+                .build();
+
+        courseRepository.save(course);
+        log.info("코스 정보 : {}", course);
+
+        return course;
+    }
+
+    private void createCourseDisability(Course course, List<Long> Disability) {
+        for (Long disabilityNum : Disability) {
+            UserDisability userDisability = UserDisability.builder()
+                    .course(course)
+                    .disability(disabilityRepository.findDisabilitiesByNumber(disabilityNum))
+                    .build();
+
+            userDisabilityRepository.save(userDisability);
+            log.info("코스 장애 정보 : {}", userDisability);
+        }
+    }
+
+    private CourseCreateRes crateCourseRes(Course course, CourseCreateReq courseCreateReq) {
+        Long day1 = 1L;
+        Long day2 = 2L;
+        Long day3 = 3L;
+
+        // 코스 내 관광지 정보 생성
+        crateUserCourse(course, courseCreateReq.getDay1(), day1);
+        crateUserCourse(course, courseCreateReq.getDay2(), day2);
+        crateUserCourse(course, courseCreateReq.getDay3(), day3);
+
+        return CourseCreateRes.builder()
+                .uuid(courseCreateReq.getUuid())
+                .course(course)
+                .disability(courseCreateReq.getDisability())
+                .startDate(course.getStartDate())
+                .endDate(course.getEndDate())
+                .day1(courseCreateReq.getDay1())
+                .day2(courseCreateReq.getDay2())
+                .day3(courseCreateReq.getDay3())
+                .build();
+    }
+
+    private void crateUserCourse(Course course, List<Long> locations, Long day) {
+        if (locations == null)
+            return ;
+
+        for (Long location : locations) {
+            UserCourse userCourse = UserCourse.builder()
+                    .course(course)
+                    .day(day)
+                    .location(locationRepository.findLocationByContentId(location))
+                    .build();
+
+            userCourseRepository.save(userCourse);
+            log.info("코스 관광지 정보 : {}", userCourse.getLocation().getContentTitle());
+        }
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/disability/domain/Disability.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/disability/domain/Disability.java
@@ -1,17 +1,17 @@
 package danpoong.mohaeng.disability.domain;
 
+import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
+@Entity
+@Table(name = "disability")
 @Getter
-@RequiredArgsConstructor
-public enum Disability {
-    SENIOR("senior"),
-    WHEELCHAIR("wheelchair"),
-    BLIND("blind"),
-    HEARING("hearing"),
-    INFANTS("infants"),
-    NONE("none");
+public class Disability {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "number")
+    private Long number;
 
-    private final String name;
+    @Column(name = "name")
+    private String name;
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/disability/domain/UserDisability.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/disability/domain/UserDisability.java
@@ -1,15 +1,15 @@
 package danpoong.mohaeng.disability.domain;
 
 import danpoong.mohaeng.course.domain.Course;
+import danpoong.mohaeng.trip_type.TripType;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Table(name = "user_disability")
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -19,11 +19,17 @@ public class UserDisability {
     @Column(name = "number")
     private Long number;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "disability", nullable = false)
-    private Disability disability;
+    @ManyToOne
+    @JoinColumn(name = "disability_number", nullable = false)
+    public Disability disability;
 
     @ManyToOne
     @JoinColumn(name = "course_number", nullable = false)
     public Course course;
+
+    @Builder
+    public UserDisability(Disability disability, Course course) {
+        this.disability = disability;
+        this.course = course;
+    }
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/disability/repository/DisabilityRepository.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/disability/repository/DisabilityRepository.java
@@ -1,0 +1,8 @@
+package danpoong.mohaeng.disability.repository;
+
+import danpoong.mohaeng.disability.domain.Disability;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DisabilityRepository extends JpaRepository<Disability, Long> {
+    Disability findDisabilitiesByNumber(Long number);
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/disability/repository/UserDisabilityRepository.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/disability/repository/UserDisabilityRepository.java
@@ -1,0 +1,7 @@
+package danpoong.mohaeng.disability.repository;
+
+import danpoong.mohaeng.disability.domain.UserDisability;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDisabilityRepository extends JpaRepository<UserDisability, Long> {
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationController.java
@@ -6,9 +6,11 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
+@Tag(name = "Location", description = "관광지 관련 API")
 public interface LocationController {
     @Operation(summary = "관광지 상세 정보 조회 API", description = "contentId를 기반으로 관광지 상세 정보를 조회하는 API입니다.")
     @ApiResponses(value = {

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/controller/LocationControllerImpl.java
@@ -2,7 +2,6 @@ package danpoong.mohaeng.location.controller;
 
 import danpoong.mohaeng.location.dto.LocationInfoRes;
 import danpoong.mohaeng.location.service.LocationService;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/location")
 @RequiredArgsConstructor
-@Tag(name = "Location", description = "관광지 관련 API")
 public class LocationControllerImpl implements LocationController {
 
     private final LocationService locationService;

--- a/Mohaeng/src/main/java/danpoong/mohaeng/trip_type/TripType.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/trip_type/TripType.java
@@ -1,15 +1,17 @@
 package danpoong.mohaeng.trip_type;
 
+import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
+@Entity
+@Table(name = "trip_type")
 @Getter
-@RequiredArgsConstructor
-public enum TripType {
-    FOREST("forest"),
-    OCEAN("ocean"),
-    CULTURE("culture"),
-    OUTSIDE("outside");
+public class TripType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "number")
+    private Long number;
 
-    private final String name;
+    @Column(name = "name")
+    private String name;
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/trip_type/UserTripType.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/trip_type/UserTripType.java
@@ -18,9 +18,9 @@ public class UserTripType {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long number;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "trip_type", nullable = false)
-    private TripType tripType;
+    @ManyToOne
+    @JoinColumn(name = "trip_type_number", nullable = false)
+    public TripType tripType;
 
     @ManyToOne
     @JoinColumn(name = "course_number", nullable = false)

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserController.java
@@ -6,23 +6,25 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Tag(name = "User", description = "유저 관련 API")
 public interface UserController{
 
     @Operation(summary = "유저 생성 API", description = "uuid 기반으로 유저 정보를 생성하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "유저 정보를 생성했습니다.", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "409", description = "이미 존재하는 유저입니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 유저입니다.", content = @Content(mediaType = "application/json"))
     })
     public ResponseEntity<String> userCreate(@RequestBody UserCreateReq userCreateReq);
 
     @Operation(summary = "유저 존재 확인 API", description = "uuid 기반으로 유저 존재 여부를 확인하는 API입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "유저 정보를 생성했습니다.", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "이미 존재하는 유저입니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "이미 존재하는 유저입니다.", content = @Content(mediaType = "application/json"))
     })
     @Parameter(name = "uuid", description = "유저 고유 ID")
     public ResponseEntity<String> userExist(@RequestParam("uuid") String uuid);

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/controller/UserControllerImpl.java
@@ -2,7 +2,6 @@ package danpoong.mohaeng.user.controller;
 
 import danpoong.mohaeng.user.dto.UserCreateReq;
 import danpoong.mohaeng.user.service.UserService;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
-@Tag(name = "User", description = "유저 관련 API")
 public class UserControllerImpl implements UserController {
 
     private final UserService userService;

--- a/Mohaeng/src/main/java/danpoong/mohaeng/user/repository/UserRepository.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/user/repository/UserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, String> {
     boolean existsByUuid(String uuid);
+    User findUserByUuid(String uuid);
 }


### PR DESCRIPTION
# 코스 등록 API
## 코스 등록 API 관련 도메인 수정 
- 기존에 Enum으로 정의했던 Disability, TripType을 테이블화 및 관련 UserDisability, UserTripType 컬럼 수정
- Course에서 여행 기간, 좌표 컬럼 추가 및 Builder 정의

## 코스 등록 로직 구현
### 코스 등록 DTO
CourseCreateReq, CourseCreateRes

### CourseService
- createCourse : 코스 정보 생성
- createCourseDisability : 코스 장애 정보 생성
- crateUserCourse : 코스 내 관광지 정보 생성
- crateCourseRes : 코스 등록 응답 정보 생성

## Swagger 적용
코스 등록 관련 Swagger 설정을 적용했습니다.
CourseController 인터페이스를 생성해 관련 내용을 분리했고, User 및 Location 관련 Swagger 적용을 수정했습니다.

close #22