### PR TITLE
[Feat] AI 추천 코스 API

### DIFF
--- a/Mohaeng/build.gradle
+++ b/Mohaeng/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/Mohaeng/src/main/java/danpoong/mohaeng/config/QueryDSLConfig.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package danpoong.mohaeng.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseController.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseController.java
@@ -1,14 +1,20 @@
 package danpoong.mohaeng.course.controller;
 
+import danpoong.mohaeng.course.dto.AICourseRes;
 import danpoong.mohaeng.course.dto.CourseCreateReq;
 import danpoong.mohaeng.course.dto.CourseCreateRes;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "Course", description = "코스 관련 API")
 public interface CourseController {
@@ -18,4 +24,23 @@ public interface CourseController {
             @ApiResponse(responseCode = "400", description = "잘못된 코스 정보입니다.", content = @Content(mediaType = "application/json")),
     })
     public ResponseEntity<CourseCreateRes> courseCreate(@RequestBody CourseCreateReq courseCreateReq);
+
+    @Operation(summary = "AI 추천 코스 API", description = "AI 추천 코스를 제공하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "AI 추천 코스", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "null", content = @Content(mediaType = "application/json")),
+    })
+    public ResponseEntity<AICourseRes> courseCreate(
+            @Parameter(description = "사용자의 장애 유형 ID 리스트 (예: 휠체어 접근 가능)", example = "[1, 2, 3]")
+            @RequestParam(value = "disability", required = false) List<Long> disability,
+
+            @Parameter(description = "사용자의 여행 타입 ID 리스트 (예: 자연, 문화 등)", example = "[101, 102]")
+            @RequestParam(value = "tripType", required = false) List<Long> tripType,
+
+            @Parameter(description = "여행할 지역 ID", example = "1")
+            @RequestParam(value = "area") Long area,
+
+            @Parameter(description = "여행 기간 (일 단위)", example = "3")
+            @RequestParam(value = "period") Long period
+    ) ;
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseControllerImpl.java
@@ -29,7 +29,7 @@ public class CourseControllerImpl implements CourseController{
     }
 
     @GetMapping("/ai-rec")
-    public ResponseEntity<AICourseRes> courseCreate(@RequestParam("diability") List<Long> disability,
+    public ResponseEntity<AICourseRes> courseCreate(@RequestParam("disability") List<Long> disability,
             @RequestParam("tripType") List<Long> tripType, @RequestParam("area") Long area, @RequestParam("period") Long period) {
         AICourseRes aiCourseRes = courseService.createAIRecCourse(disability, tripType, area, period);
 

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseControllerImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/controller/CourseControllerImpl.java
@@ -1,15 +1,15 @@
 package danpoong.mohaeng.course.controller;
 
+import danpoong.mohaeng.course.dto.AICourseRes;
 import danpoong.mohaeng.course.dto.CourseCreateReq;
 import danpoong.mohaeng.course.dto.CourseCreateRes;
 import danpoong.mohaeng.course.service.CourseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/course")
@@ -26,5 +26,16 @@ public class CourseControllerImpl implements CourseController{
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(courseCreateRes);
+    }
+
+    @GetMapping("/ai-rec")
+    public ResponseEntity<AICourseRes> courseCreate(@RequestParam("diability") List<Long> disability,
+            @RequestParam("tripType") List<Long> tripType, @RequestParam("area") Long area, @RequestParam("period") Long period) {
+        AICourseRes aiCourseRes = courseService.createAIRecCourse(disability, tripType, area, period);
+
+        if (aiCourseRes == null || aiCourseRes.getDay1() == null)
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(aiCourseRes);
     }
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/AICourseRes.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/AICourseRes.java
@@ -1,0 +1,49 @@
+package danpoong.mohaeng.course.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "AI 추천 코스 응답 Body")
+public class AICourseRes {
+    @Schema(description = "여행할 지역 이름",
+            example = "Seoul")
+    private String area;
+
+    @Schema(description = "여행 시작 위치의 GPS X 좌표",
+            example = "37.5665")
+    private Double gpsX;
+
+    @Schema(description = "여행 시작 위치의 GPS Y 좌표",
+            example = "126.9780")
+    private Double gpsY;
+
+    @Schema(description = "여행 기간 (일 단위)",
+            example = "3")
+    private Long period;
+
+    @Schema(description = "첫째 날 방문 장소 ID 리스트",
+            example = "[101, 102, 103]")
+    private List<Long> day1;
+
+    @Schema(description = "둘째 날 방문 장소 ID 리스트",
+            example = "[201, 202, 203]")
+    private List<Long> day2;
+
+    @Schema(description = "셋째 날 방문 장소 ID 리스트",
+            example = "[301, 302, 303]")
+    private List<Long> day3;
+
+    @Builder
+    public AICourseRes(String area, Double gpsX, Double gpsY, Long period) {
+        this.area = area;
+        this.gpsX = gpsX;
+        this.gpsY = gpsY;
+        this.period = period;
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/ChatGPTRes.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/ChatGPTRes.java
@@ -1,0 +1,14 @@
+package danpoong.mohaeng.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ChatGPTRes {
+    @JsonProperty("choices")
+    private List<Choice> choice;
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/Choice.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/Choice.java
@@ -1,0 +1,10 @@
+package danpoong.mohaeng.course.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Choice {
+    private Message message;
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/Message.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/dto/Message.java
@@ -1,0 +1,10 @@
+package danpoong.mohaeng.course.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Message {
+    private String content;
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/service/AIRecService.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/service/AIRecService.java
@@ -1,0 +1,116 @@
+package danpoong.mohaeng.course.service;
+
+import danpoong.mohaeng.course.dto.AICourseRes;
+import danpoong.mohaeng.course.dto.ChatGPTRes;
+import danpoong.mohaeng.location.domain.Location;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import org.springframework.http.HttpHeaders;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AIRecService {
+    @Value("${openai.api.url}")
+    private String openAiApiUrl;
+
+    @Value("${openai.api.key}")
+    private String openAiApiKey;
+
+    @Value("${openai.finetuning.model}")
+    private String finetuningModel;
+
+    private final RestTemplate restTemplate;
+
+    public AICourseRes generateCourse(List<Location> locations, List<Location> restaurants, String area, Long period) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", finetuningModel);
+        body.put("messages", List.of(Map.of(
+                "role", "user",
+                "content", generatePrompt(locations, restaurants, area, period)
+        )));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        headers.set("Authorization", "Bearer " + openAiApiKey);
+
+        // OpenAI API 호출
+        ResponseEntity<ChatGPTRes> response = restTemplate.postForEntity(
+                openAiApiUrl, new HttpEntity<>(body, headers), ChatGPTRes.class);
+
+        log.info("Full OpenAI API Response: {}", response.getBody());
+
+        // 응답 처리
+        String aiResponse = response.getBody().getChoice().getFirst().getMessage().getContent();
+        log.info("AI Response Content: {}", aiResponse);
+
+        Map<String, List<Long>> dayWiseContentIds = parseDayWiseContentIds(aiResponse);
+        
+        AICourseRes aiCourseRes = new AICourseRes(area, locations.getFirst().getGpsX(), locations.getFirst().getGpsY(), period);
+        aiCourseRes.setDay1(dayWiseContentIds.getOrDefault("Day 1", List.of()));
+        aiCourseRes.setDay2(dayWiseContentIds.getOrDefault("Day 2", List.of()));
+        aiCourseRes.setDay3(dayWiseContentIds.getOrDefault("Day 3", List.of()));
+
+        return aiCourseRes; // 줄 단위로 결과 반환
+    }
+
+    private String generatePrompt(List<Location> locations, List<Location> restaurants, String area, Long period) {
+
+        StringBuilder prompt = new StringBuilder();
+        Long tripPeriod = period + 1L;
+
+        String defaultPrompt = "나는 " + tripPeriod + "일 동안 " + area + "를 여행할 코스를 추천 받고 싶어. ";
+        prompt.append(defaultPrompt);
+        prompt.append("내가 보내는 Tourist, Restaurant 리스트에서 장소의 gpsX, gpsY를 기반으로 이동 거리와 시간을 고려해서 코스를 추천해줘. ");
+        prompt.append("하루에 contentTypeId가 12인 장소 3곳, contentTypeId가 39인 장소 1곳을 추천해줘. ");
+        prompt.append("코스를 추천할 때 Day 1:[contentId 리스트] 와 같은 구조로 제공해줘.");
+
+        // Tourist 리스트 추가
+        prompt.append("Tourist : [");
+        prompt.append(locations.stream()
+                .map(Location::toPrompt)
+                .collect(Collectors.joining(", ")));
+        prompt.append("]\n");
+
+        // Restaurant 리스트 추가
+        prompt.append("Restaurants: [");
+        prompt.append(restaurants.stream()
+                .map(Location::toPrompt)
+                .collect(Collectors.joining(", ")));
+        prompt.append("]");
+
+        log.info("Generated Prompt: {}", prompt);
+        return prompt.toString();
+    }
+
+    private Map<String, List<Long>> parseDayWiseContentIds(String aiResponse) {
+        Map<String, List<Long>> dayWiseContentIds = new LinkedHashMap<>();
+
+        // 정규표현식으로 Day X와 해당 리스트 추출
+        Pattern pattern = Pattern.compile("(Day \\d+): \\[(.*?)\\]");
+        Matcher matcher = pattern.matcher(aiResponse);
+
+        while (matcher.find()) {
+            String day = matcher.group(1); // Day 이름 (예: Day 1)
+            String[] ids = matcher.group(2).split(","); // contentId 리스트 추출
+            List<Long> contentIds = Arrays.stream(ids)
+                    .map(String::trim) // 공백 제거
+                    .map(Long::parseLong) // Long 타입 변환
+                    .collect(Collectors.toList()); // Collectors.toList() 사용
+            dayWiseContentIds.put(day, contentIds);
+        }
+
+        return dayWiseContentIds;
+    }
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/course/service/CourseService.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/course/service/CourseService.java
@@ -4,6 +4,7 @@ import danpoong.mohaeng.area.domain.Area;
 import danpoong.mohaeng.area.repository.AreaRepository;
 import danpoong.mohaeng.course.domain.Course;
 import danpoong.mohaeng.course.domain.UserCourse;
+import danpoong.mohaeng.course.dto.AICourseRes;
 import danpoong.mohaeng.course.dto.CourseCreateReq;
 import danpoong.mohaeng.course.dto.CourseCreateRes;
 import danpoong.mohaeng.course.repository.CourseRepository;
@@ -11,6 +12,7 @@ import danpoong.mohaeng.course.repository.UserCourseRepository;
 import danpoong.mohaeng.disability.domain.UserDisability;
 import danpoong.mohaeng.disability.repository.DisabilityRepository;
 import danpoong.mohaeng.disability.repository.UserDisabilityRepository;
+import danpoong.mohaeng.location.domain.Location;
 import danpoong.mohaeng.location.repository.LocationRepository;
 import danpoong.mohaeng.user.domain.User;
 import danpoong.mohaeng.user.repository.UserRepository;
@@ -32,6 +34,7 @@ public class CourseService {
     private final DisabilityRepository disabilityRepository;
     private final UserDisabilityRepository userDisabilityRepository;
     private final CourseRepository courseRepository;
+    private final AIRecService aiRecService;
 
     public CourseCreateRes createTrip(CourseCreateReq courseCreateReq) {
         // 코스 정보 생성
@@ -113,5 +116,21 @@ public class CourseService {
             userCourseRepository.save(userCourse);
             log.info("코스 관광지 정보 : {}", userCourse.getLocation().getContentTitle());
         }
+    }
+
+    public AICourseRes createAIRecCourse(List<Long> disability, List<Long> tripType, Long area, Long period) {
+
+        // 필터링 된 관광지
+        List<Location> filteredLocation = locationRepository.filterByAreaAndDisabilityAndTravelType(
+                        area, disability, tripType).stream()
+                .limit(80)
+                .toList();
+
+        // 필터링 된 음식점
+        List<Location> filteredRestaurant = locationRepository.filterByAreaAndContentType(area).stream()
+                .limit(80)
+                .toList();
+
+        return aiRecService.generateCourse(filteredLocation, filteredRestaurant, areaRepository.findByNumber(area).getName(), period);
     }
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/domain/Location.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/domain/Location.java
@@ -74,4 +74,12 @@ public class Location {
     @Column(name = "thumbnail_image")
     private String thumbnailImage; // 썸네일 이미지
 
+    public String toPrompt() {
+        return "[contentId : " + getContentId()
+                + ", contentTypeId : " + getContentTypeId()
+                + ", description : " + getDescription()
+                + ", gpsX : " + getGpsX()
+                + ", gpsY : " + getGpsY()
+                + ", addr : " + getAddr() + "]";
+    }
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/repository/LocationRepository.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/repository/LocationRepository.java
@@ -4,6 +4,6 @@ import danpoong.mohaeng.location.domain.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
-public interface LocationRepository extends JpaRepository<Location, Long> {
+public interface LocationRepository extends JpaRepository<Location, Long>, LocationRepositoryCustom {
     Location findLocationByContentId(Long contentId);
 }

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/repository/LocationRepositoryCustom.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/repository/LocationRepositoryCustom.java
@@ -1,0 +1,12 @@
+package danpoong.mohaeng.location.repository;
+
+import danpoong.mohaeng.location.domain.Location;
+
+import java.util.List;
+import java.util.Set;
+
+public interface LocationRepositoryCustom {
+    Set<Location> filterByAreaAndDisabilityAndTravelType(Long area, List<Long> disabilities, List<Long> travelTypes);
+    Set<Location> filterByAreaAndContentType(Long area);
+
+}

--- a/Mohaeng/src/main/java/danpoong/mohaeng/location/repository/LocationRepositoryImpl.java
+++ b/Mohaeng/src/main/java/danpoong/mohaeng/location/repository/LocationRepositoryImpl.java
@@ -1,0 +1,161 @@
+package danpoong.mohaeng.location.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import danpoong.mohaeng.disabled.domain.QDisabled;
+import danpoong.mohaeng.location.domain.Location;
+import danpoong.mohaeng.location.domain.QLocation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class LocationRepositoryImpl implements LocationRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Set<Location> filterByAreaAndDisabilityAndTravelType(Long area, List<Long> disabilities, List<Long> tripTypes) {
+        BooleanBuilder conditions = new BooleanBuilder();
+
+        QLocation l = QLocation.location;
+        QDisabled d = QDisabled.disabled;
+
+        Long locationId = 12L;
+
+        // 관광지만 선택
+        conditions.and(addContentTypeConditions(locationId));
+
+        // 지역 조건 추가
+        conditions.and(addAreaConditions(area));
+
+        // 장애 정보에 따른 조건 추가
+        conditions.and(addDisabilityConditions(disabilities));
+
+        // 여행 타입 조건 추가
+        conditions.and(addTripTypeConditions(tripTypes));
+
+        var query = queryFactory.selectFrom(l)
+                .join(l.disabled, d)
+                .where(conditions);
+
+        List<Location> resultList = query.fetch();
+
+        log.info("list size : {}", resultList.size());
+        return new HashSet<>(resultList);  // 중복 제거를 위해 Set으로 변환
+    }
+
+    @Override
+    public Set<Location> filterByAreaAndContentType(Long area) {
+        BooleanBuilder conditions = new BooleanBuilder();
+
+        QLocation l = QLocation.location;
+        Long restaurantId = 39L;
+
+        // 관광지만 선택
+        conditions.and(addContentTypeConditions(restaurantId));
+
+        // 지역 조건 추가
+        conditions.and(addAreaConditions(area));
+
+        var query = queryFactory.selectFrom(l)
+                .where(conditions);
+
+        List<Location> resultList = query.fetch();
+
+        log.info("list size : {}", resultList.size());
+        return new HashSet<>(resultList);  // 중복 제거를 위해 Set으로 변환
+    }
+
+    private BooleanBuilder addContentTypeConditions(Long contentType) {
+        BooleanBuilder contentTypeConditions = new BooleanBuilder();
+
+        QLocation l = QLocation.location;
+        contentTypeConditions.and(l.contentTypeId.eq(contentType));
+
+        return contentTypeConditions;
+    }
+
+    private BooleanBuilder addAreaConditions(Long area) {
+        BooleanBuilder areaConditions = new BooleanBuilder();
+
+        QLocation l = QLocation.location;
+        areaConditions.and(l.area.number.eq(area));
+
+        return areaConditions;
+    }
+
+    private BooleanBuilder addDisabilityConditions(List<Long> disabilities) {
+        BooleanBuilder disabilityConditions = new BooleanBuilder();
+
+        QDisabled d = QDisabled.disabled;
+
+        for (Long disability : disabilities) {
+            if (disability == 0 || disability == 1) {
+                disabilityConditions.and(d.elevator.isNotNull())
+                        .and(d.entrance.isNotNull())
+                        .and(d.publicTransport.isNotNull());
+            }
+            else if (disability == 2) {
+                disabilityConditions.and(d.braileBlock.isNotNull())
+                        .and(d.guideHuman.isNotNull());
+            }
+            else if (disability == 3) {
+                disabilityConditions.and(d.signGuide.isNotNull()
+                        .or(d.videoGuide.isNotNull())
+                        .or(d.hearingRoom.isNotNull())
+                        .or(d.hearingHandicapEtc.isNotNull()));
+            }
+            else if (disability == 4) {
+                disabilityConditions.and(d.stroller.isNotNull()
+                        .or(d.lactationRoom.isNotNull())
+                        .or(d.babySpareChair.isNotNull())
+                        .or(d.infantsFamilyEtc.isNotNull()));
+            }
+        }
+
+        return disabilityConditions;
+    }
+
+    private BooleanBuilder addTripTypeConditions(List<Long> tripTypes) {
+        BooleanBuilder travelTypeConditions = new BooleanBuilder();
+
+        QLocation l = QLocation.location;
+
+        List<String> forestType = Arrays.asList("숲", "휴양림", "산림욕장", "치유");
+        List<String> oceanType = Arrays.asList("해수욕장", "바다", "물놀이", "호수");
+        List<String> cultureType = Arrays.asList("박물관", "미술관", "역사", "문화", "사찰");
+        List<String> outsideType = Arrays.asList("가족", "어린이", "공원", "파크", "레저");
+
+        for (Long tripType : tripTypes) {
+            if (tripType == 0) {
+                for (String type : forestType) {
+                    travelTypeConditions.or(l.description.contains(type));
+                }
+            }
+            else if (tripType == 1){
+                for (String type : oceanType) {
+                    travelTypeConditions.or(l.description.contains(type));
+                }
+            }
+            else if (tripType == 2){
+                for (String type : cultureType) {
+                    travelTypeConditions.or(l.description.contains(type));
+                }
+            }
+            else if (tripType == 3){
+                for (String type : outsideType) {
+                    travelTypeConditions.or(l.description.contains(type));
+                }
+            }
+        }
+
+        return travelTypeConditions;
+    }
+}


### PR DESCRIPTION
# 추후 보완
DB 인덱스 생성, 프롬프트 최적화를 통한 성능 향상이 필요합니다.

# 구현 사항
## GPT 통신용 DTO 생성
**ChatGPTRes**
- List<Choice> choice
@JsonProperty를 통해 매핑시켜줘야 오류가 나지 않습니다.

**Choice**
- Message

## 관광지, 음식점 조회
사용자의 니즈에 맞춰 관광지, 음식점을 조회하기 위해 동적 쿼리 생성이 가능한 QueryDSL을 적용했습니다.

**관광지**
- 지역, 장애 정보, 여행 타입 고려

**음식점**
- 지역 고려

## AI 추천 코스 로직
프롬프트 생성시 Location 중 필요한 내용을 프롬프트화 하는 함수를 구현했습니다.
generateCourse()에서 필터링 된 관광지 및 음식점과 프롬프트를 생성해 파인튜닝한 모델에 여행 코스를 요청합니다.
AI가 리스트를 기반으로 추천한 여행 코스를 받아와 Response에 맞게 contentId를 파싱하고, 리턴합니다.

## Swagger 적용
AI 추천 코스 API에 Swagger를 적용했습니다.